### PR TITLE
Move lodash to deps and make tree-shakeable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10109,8 +10109,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -10134,12 +10133,6 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
-      "dev": true
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.kebabcase": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "docs:build": "vuepress build docs"
   },
   "dependencies": {
-    "vue": "^2.5.17"
+    "vue": "^2.5.17",
+    "lodash": "4.17.15"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.6.3",
@@ -36,8 +37,6 @@
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0-0",
     "lint-staged": "^7.2.2",
-    "lodash.clonedeep": "4.5.0",
-    "lodash.isequal": "4.5.0",
     "mocha-junit-reporter": "^1.18.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^7.1.0",

--- a/src/VTr.vue
+++ b/src/VTr.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import isEqual from 'lodash.isequal'
+import isEqual from 'lodash/isequal'
 
 export default {
   name: 'v-tr',

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,5 @@
-import cloneDeep from 'lodash.clonedeep'
-import isEqual from 'lodash.isequal'
+import cloneDeep from 'lodash/clonedeep'
+import isEqual from 'lodash/isequal'
 
 export default {
   data: () => ({


### PR DESCRIPTION
- Import `lodash` instead of individual `lodash` packages (this will only be for our fork)
- Move this import to `dependencies` (this was an error on my part).
- Import `cloneDeep` and `isEqual` in a way to make them tree-shakeable.